### PR TITLE
Add Sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,13 @@
+:concurrency: 5
+:queues:
+  - [critical, 2]
+  - default
+  - low
+  - mailers
+  - exports
+  - block_user
+  - events
+  - translations
+  - metrics
+  - newsletters_opt_in
+  - user_report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - storage:/app/storage
     links:
       - redis
-    command: bundle exec sidekiq
+    command: bundle exec sidekiq -C config/sidekiq.yml
 
   redis:
     image: redis


### PR DESCRIPTION
### What

- [x] Adds a `config/sidekiq.yml` that specifies the queues that Sidekiq should process.

### Why
Participatory processes exports were never delivered. By default, sidekiq only processes `default`, `critical`, and `low` queues unless others are specified. The exports are enqueued on an `exports` queue that was never processed.