### PR TITLE
Sentry backend improvements + frontend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,4 +9,5 @@ SMTP_PASSWORD=mail-password
 SMTP_DOMAIN=primariatm.ro
 SMTP_ADDRESS=smtp.sendgrid.net
 FROM_ADDRESS=noreply@primariatm.ro
-SENTRY_DSN=https://x@y.ingest.sentry.io/z
+SENTRY_BACKEND_DSN=https://x@y.ingest.sentry.io/z
+SENTRY_FRONTEND_DSN=https://x@y.ingest.sentry.io/z

--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,6 @@ end
 
 gem "sentry-ruby"
 gem "sentry-rails"
+gem "sentry-sidekiq"
 gem "dotenv"
 gem "dotenv-rails", groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,6 +714,9 @@ GEM
     sentry-ruby-core (4.7.3)
       concurrent-ruby
       faraday
+    sentry-sidekiq (4.7.3)
+      sentry-ruby-core (~> 4.7.0)
+      sidekiq (>= 3.0)
     seven_zip_ruby (1.3.0)
     sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
@@ -824,6 +827,7 @@ DEPENDENCIES
   rubocop-shopify
   sentry-rails
   sentry-ruby
+  sentry-sidekiq
   sidekiq
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)

--- a/app/packs/entrypoints/error_tracking.js
+++ b/app/packs/entrypoints/error_tracking.js
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/browser";
+import { Integrations } from "@sentry/tracing";
+
+Sentry.init({
+  dsn: window.SENTRY_DSN,
+  environment: "production",
+  integrations: [new Integrations.BrowserTracing()],
+  tracesSampleRate: 0.2,
+});

--- a/app/packs/entrypoints/error_tracking.js
+++ b/app/packs/entrypoints/error_tracking.js
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/browser";
 import { Integrations } from "@sentry/tracing";
 
 Sentry.init({
-  dsn: window.SENTRY_DSN,
+  dsn: window.SENTRY_FRONTEND_DSN,
   environment: "production",
   integrations: [new Integrations.BrowserTracing()],
   tracesSampleRate: 0.2,

--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -164,7 +164,7 @@
 
 <%# if Rails.env.production? %>
   <script type='text/javascript'>
-    window.SENTRY_DSN = "<%= ENV["SENTRY_FRONTEND_DSN"] %>"
+    window.SENTRY_FRONTEND_DSN = "<%= ENV["SENTRY_FRONTEND_DSN"] %>"
   </script>
   <%= javascript_pack_tag "error_tracking" %>
 <%# end %>

--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -161,4 +161,11 @@
   }
 
 </style>
+
+<%# if Rails.env.production? %>
+  <script type='text/javascript'>
+    window.SENTRY_DSN = "<%= ENV["SENTRY_FRONTEND_DSN"] %>"
+  </script>
+  <%= javascript_pack_tag "error_tracking" %>
+<%# end %>
 <script src="https://cdn.usefathom.com/script.js" data-site="DJSUNPDV" defer></script>

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,13 +1,41 @@
+# frozen_string_literal: true
+
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.enabled_environments = %w[production]
 
-  # Set tracesSampleRate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  # We recommend adjusting this value in production
-  config.traces_sample_rate = 0.5
-  # or
-  config.traces_sampler = lambda do |context|
-    true
+  # Sanitize parameters before sending to Sentry
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda do |event, _hint|
+    filter.filter(event.to_hash)
   end
+
+  config.traces_sampler = lambda do |sampling_context|
+    # if this is the continuation of a trace, just use that decision (rate controlled by the caller)
+    unless sampling_context[:parent_sampled].nil?
+      next sampling_context[:parent_sampled]
+    end
+
+    # transaction_context is the transaction object in hash form
+    # keep in mind that sampling happens right after the transaction is initialized
+    # for example, at the beginning of the request
+    transaction_context = sampling_context[:transaction_context]
+
+    # transaction_context helps you sample transactions with more sophistication
+    # for example, you can provide different sample rates based on the operation or name
+    op = transaction_context[:op]
+
+    case op
+    when /request/
+      0.1
+    when /sidekiq/
+      0.01 # we want to set a lower rate for background jobs since Decidim has a lot
+    else
+      0.0 # ignore all other transactions
+    end
+  end
+
+  # Integrations specific configurations
+  config.sidekiq.report_after_job_retries = true
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sentry.init do |config|
-  config.dsn = ENV["SENTRY_DSN"]
+  config.dsn = ENV["SENTRY_BACKEND_DSN"]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.enabled_environments = %w[production]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       - SMTP_PASSWORD=${SMTP_PASSWORD}
       - SMTP_ADDRESS=${SMTP_ADDRESS}
       - FROM_ADDRESS=${FROM_ADDRESS}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - SENTRY_BACKEND_DSN=${SENTRY_BACKEND_DSN}
+      - SENTRY_FRONTEND_DSN=${SENTRY_FRONTEND_DSN}
     volumes:
       - logs:/app/log
       - storage:/app/storage
@@ -39,7 +40,8 @@ services:
       - SMTP_PASSWORD=${SMTP_PASSWORD}
       - SMTP_ADDRESS=${SMTP_ADDRESS}
       - FROM_ADDRESS=${FROM_ADDRESS}
-      - SENTRY_DSN=${SENTRY_DSN}
+      - SENTRY_BACKEND_DSN=${SENTRY_BACKEND_DSN}
+      - SENTRY_FRONTEND_DSN=${SENTRY_FRONTEND_DSN}
     volumes:
       - logs:/app/log
       - storage:/app/storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@decidim/browserslist-config": "^0.25.0",
         "@decidim/core": "^0.25.0",
         "@decidim/elections": "^0.25.0",
-        "@decidim/webpacker": "^0.25.0"
+        "@decidim/webpacker": "^0.25.0",
+        "@sentry/browser": "^6.16.1",
+        "@sentry/tracing": "^6.16.1"
       },
       "devDependencies": {
         "@decidim/dev": "^0.25.0",
@@ -2135,6 +2137,126 @@
         "node": ">= 12.13.0 || >=14",
         "yarn": ">=1 <4"
       }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.16.1.tgz",
+      "integrity": "sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==",
+      "dependencies": {
+        "@sentry/core": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/core": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
+      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
+      "dependencies": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/hub": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
+      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
+      "dependencies": {
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
+      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
+      "dependencies": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
+      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
+      "dependencies": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "dependencies": {
+        "@sentry/types": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@stylelint/postcss-css-in-js": {
       "version": "0.37.2",
@@ -14120,6 +14242,8 @@
     },
     "node_modules/webpack-config-utils/node_modules/webpack-combine-loaders": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/webpack-combine-loaders/-/webpack-combine-loaders-2.0.4.tgz",
+      "integrity": "sha512-5O5PYVE5tZ3I3uUm3QB7niLEJzLketl8hvAcJwa4YmwNWS/vixfVsqhtUaBciP8J4u/GwIHV52d7kkgZJFvDnw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -16143,6 +16267,117 @@
         "webpack-cli": "^4.8.0",
         "webpack-merge": "^5.8.0",
         "webpack-sources": "^3.2.0"
+      }
+    },
+    "@sentry/browser": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.16.1.tgz",
+      "integrity": "sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==",
+      "requires": {
+        "@sentry/core": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
+      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
+      "requires": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
+      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
+      "requires": {
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
+      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
+      "requires": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
+      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
+      "requires": {
+        "@sentry/hub": "6.16.1",
+        "@sentry/minimal": "6.16.1",
+        "@sentry/types": "6.16.1",
+        "@sentry/utils": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
+      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ=="
+    },
+    "@sentry/utils": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
+      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "requires": {
+        "@sentry/types": "6.16.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@stylelint/postcss-css-in-js": {
@@ -25475,6 +25710,8 @@
         },
         "webpack-combine-loaders": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/webpack-combine-loaders/-/webpack-combine-loaders-2.0.4.tgz",
+          "integrity": "sha512-5O5PYVE5tZ3I3uUm3QB7niLEJzLketl8hvAcJwa4YmwNWS/vixfVsqhtUaBciP8J4u/GwIHV52d7kkgZJFvDnw==",
           "bundled": true,
           "requires": {
             "qs": "^6.5.2"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "@decidim/browserslist-config": "^0.25.0",
     "@decidim/core": "^0.25.0",
     "@decidim/elections": "^0.25.0",
-    "@decidim/webpacker": "^0.25.0"
+    "@decidim/webpacker": "^0.25.0",
+    "@sentry/browser": "^6.16.1",
+    "@sentry/tracing": "^6.16.1"
   },
   "version": "0.1.0",
   "babel": {


### PR DESCRIPTION
### What

- [x] Configure Sentry to only run in `production` environment
- [x] Add Sentry for front-end (JS errors) 
- [x] Add Sentry for Sidekiq jobs
- [x] Enable Sentry performance tracing for both back-end + front-end
- [x] Rename `SENTRY_DSN` env var to `SENTRY_BACKEND_DSN` for better consistency across Sentry env vars.

### Why
Improve error handling via Sentry.