### PR TITLE
Participatory process images collections

### DIFF
--- a/app/views/decidim/application/_photo_gallery.html.erb
+++ b/app/views/decidim/application/_photo_gallery.html.erb
@@ -1,0 +1,11 @@
+<div class="gallery row">
+  <% photos.in_groups_of(3, false).each do |group| %>
+    <% group.each_with_index do |photo, index| %>
+      <div class="columns small-6 medium-4 <%= (index == 2 || photo == group.last ? "end" : "") %>">
+        <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
+          <%= image_tag photo.thumbnail_url, class:"thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/decidim/application/_photos.html.erb
+++ b/app/views/decidim/application/_photos.html.erb
@@ -1,0 +1,13 @@
+<% if photos.any? %>
+  <div class="section images">
+    <h3 class="section-heading"><%= t("decidim.application.photos.related_photos") %></h3>
+    <% if (photos_without_collection = photos.reject(&:attachment_collection_id?)).any? %>
+      <div class="card card--list">
+        <%= render partial: "decidim/application/photo_gallery.html", locals: { photos: photos_without_collection } %>
+      </div>
+    <% end %>
+    <% photos.select(&:attachment_collection_id?).group_by(&:attachment_collection).sort_by { |c, d| c.weight }.each do |collection, photos| %>
+      <%= render partial: "decidim/application/photos_collection.html", locals: { attachment_collection: collection, photos: photos } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/decidim/application/_photos_collection.html.erb
+++ b/app/views/decidim/application/_photos_collection.html.erb
@@ -1,0 +1,22 @@
+<% unless attachment_collection.unused? %>
+  <div class="docs__container">
+    <span data-toggle="docs-photo-collection-<%= attachment_collection.id %>"><%= icon "caret-right", class: "icon--small", role: "img", "aria-hidden": true %>&nbsp;
+      <strong><%= translated_attribute(attachment_collection.name) %></strong>
+
+      <% attachment_collection_documents_count =  attachment_collection.attachments.select(&:photo?).count %>
+      <small>(<%= attachment_collection_documents_count %> <%= t("decidim.application.collection.photos", count: attachment_collection_documents_count) %>)</small>
+    </span>
+
+    <div id="docs-photo-collection-<%= attachment_collection.id %>" class="docs__content hide" data-toggler=".hide">
+      <p><%= translated_attribute(attachment_collection.description) %></p>
+
+      <div class="card card--list">
+        <% photos.each do |photo| %>
+          <%= link_to photo.big_url, target: "_blank", rel: "noopener" do %>
+            <%= image_tag photo.thumbnail_url, class:"thumbnail", alt: strip_tags(translated_attribute(photo.title)) %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,8 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  decidim:
+    application:
+      collection:
+        photos:
+          one: Image
+          few: Images
+          other: Images

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,0 +1,8 @@
+ro:
+  decidim:
+    application:
+      collection:
+        photos:
+          one: Imagine
+          few: Imagini
+          other: Imagini


### PR DESCRIPTION
### What

- [x] render process images in selected admin folders

### Why
Our participatory processes support documents and images as files that can be organized in folders. Documents seem to properly have a logic for rendering inside folders on the front-end, whereas images are missing this logic, thus all photos are rendered in a single gallery.

This PR addresses this issue and ensures feature parity with how the document collections work.

### Screenshots
| Before | After |
| --- | --- |
| <img width="2558" alt="image" src="https://user-images.githubusercontent.com/1855287/198275868-17951805-f950-4eb5-bc1e-3e981a31069d.png"> | ![WhatsApp Image 2022-10-27 at 2 40 22 PM](https://user-images.githubusercontent.com/1855287/198275909-99b13b07-cfd2-4f79-8faf-9b95522cda49.jpeg) |
|  | ![WhatsApp Image 2022-10-27 at 2 40 22 PM (1)](https://user-images.githubusercontent.com/1855287/198275950-5e864420-b104-40e6-a6e8-0d0be66dd498.jpeg) |